### PR TITLE
fix: allow to fetch not only json schemas

### DIFF
--- a/mkdocs_asyncapi_tag/mkdocs_asyncapi_plugin.py
+++ b/mkdocs_asyncapi_tag/mkdocs_asyncapi_plugin.py
@@ -97,7 +97,7 @@ class AsyncAPIPlugin(BasePlugin):
                     if (!response.ok) {{
                         throw new Error(`Failed to fetch schema. Status: ${{response.status}}`);
                     }}
-                    return response.json();
+                    return response.text();
                 }}).then(schemaDoc => {{
                 
                     console.log('Schema fetched successfully:', schemaDoc);


### PR DESCRIPTION
In the 'readme.md' mentioned that both formats `json` and `yaml` are supported, but in the generated js code fetched schema is trying to parse as `json` only, so `yaml` format is not supported in reality.